### PR TITLE
CBP-10236 - GHA publish action doesn't not show the Published by URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,4 +61,4 @@ runs:
         INPUT_VERSION: ${{ inputs.version }}
         INPUT_URL: ${{ inputs.url }}
         INPUT_DIGEST: ${{ inputs.digest }}
-        GITHUB_RUN_URL: ${{ github.repositoryUrl }}/actions/jobs/${{ github.job }}
+        GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/action.yml
+++ b/action.yml
@@ -35,12 +35,12 @@ runs:
         echo '"operation": "'"PUBLISHED"'", "sourceUrl":"'"$GITHUB_RUN_URL"'", "digest": "'"$INPUT_DIGEST"'" }' >> /tmp/payload.json
 
         #DEBUG
-        #echo This is the payload
-        #cat /tmp/payload.json
-        #echo This is the POST
-        #echo "$INPUT_CLOUDBEES_URL/v2/resources/$INPUT_COMPONENT_ID/artifactinfos"
-        #echo CLOUDBEES_PLATFORM_PAT="$INPUT_JWT"
-        #echo CLOUDBEES_PLATFORM_URL="$INPUT_CLOUDBEES_URL"
+        echo This is the payload
+        cat /tmp/payload.json
+        echo This is the POST
+        echo "$INPUT_CLOUDBEES_URL/v2/resources/$INPUT_COMPONENT_ID/artifactinfos"
+        echo CLOUDBEES_PLATFORM_PAT="$INPUT_JWT"
+        echo CLOUDBEES_PLATFORM_URL="$INPUT_CLOUDBEES_URL"
 
         # Make Platform API call to create artifact_info record
         response=$(curl --fail-with-body  -X 'POST' "$INPUT_CLOUDBEES_URL/v2/resources/$INPUT_COMPONENT_ID/artifactinfos" \

--- a/action.yml
+++ b/action.yml
@@ -34,14 +34,6 @@ runs:
         echo '{ "name": "'"$INPUT_NAME"'", "url": "'"$INPUT_URL"'", "version": "'"$INPUT_VERSION"'", ' > /tmp/payload.json
         echo '"operation": "'"PUBLISHED"'", "sourceUrl":"'"$GITHUB_RUN_URL"'", "digest": "'"$INPUT_DIGEST"'" }' >> /tmp/payload.json
 
-        #DEBUG
-        echo This is the payload
-        cat /tmp/payload.json
-        echo This is the POST
-        echo "$INPUT_CLOUDBEES_URL/v2/resources/$INPUT_COMPONENT_ID/artifactinfos"
-        echo CLOUDBEES_PLATFORM_PAT="$INPUT_JWT"
-        echo CLOUDBEES_PLATFORM_URL="$INPUT_CLOUDBEES_URL"
-
         # Make Platform API call to create artifact_info record
         response=$(curl --fail-with-body  -X 'POST' "$INPUT_CLOUDBEES_URL/v2/resources/$INPUT_COMPONENT_ID/artifactinfos" \
           -H "Authorization: Bearer $INPUT_JWT" -H 'Content-Type: application/json' \

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,14 @@ runs:
         echo '{ "name": "'"$INPUT_NAME"'", "url": "'"$INPUT_URL"'", "version": "'"$INPUT_VERSION"'", ' > /tmp/payload.json
         echo '"operation": "'"PUBLISHED"'", "sourceUrl":"'"$GITHUB_RUN_URL"'", "digest": "'"$INPUT_DIGEST"'" }' >> /tmp/payload.json
 
+        #DEBUG
+        #echo This is the payload
+        #cat /tmp/payload.json
+        #echo This is the POST
+        #echo "$INPUT_CLOUDBEES_URL/v2/resources/$INPUT_COMPONENT_ID/artifactinfos"
+        #echo CLOUDBEES_PLATFORM_PAT="$INPUT_JWT"
+        #echo CLOUDBEES_PLATFORM_URL="$INPUT_CLOUDBEES_URL"
+
         # Make Platform API call to create artifact_info record
         response=$(curl --fail-with-body  -X 'POST' "$INPUT_CLOUDBEES_URL/v2/resources/$INPUT_COMPONENT_ID/artifactinfos" \
           -H "Authorization: Bearer $INPUT_JWT" -H 'Content-Type: application/json' \


### PR DESCRIPTION
Change 
        GITHUB_RUN_URL: ${{ github.repositoryUrl }}/actions/jobs/${{ github.job }}
to:
        GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
